### PR TITLE
Fixes onMessage and adds onHide hook

### DIFF
--- a/IntercomWebView.html
+++ b/IntercomWebView.html
@@ -1,47 +1,15 @@
-    <!DOCTYPE html>
-    <head>
-        <script>
-//      intercom JS library
-        var APP_ID = '';
-        (function(){
-        debugger;
-        console.log("Executing function main...");
-        var w=window;
-        var ic=w.Intercom;
-        if(typeof ic==="function"){
-        ic('reattach_activator');
-        ic('update',intercomSettings);
-        }else{
-        var d=document;
-        var i=function(){
-        i.c(arguments)
-        };
-        i.q=[];
-        i.c=function(args){
-        i.q.push(args)
-        };
-        w.Intercom=i;
+<!DOCTYPE html>
 
-        function l(){
-        debugger;
-        console.log("Executing function l...");
-        var s=d.createElement('script');
-        s.type='text/javascript';
-        s.async=true;
-        s.src='https://widget.intercom.io/widget/' + APP_ID;
-        var x=d.getElementsByTagName('script')[0];
-        x.parentNode.insertBefore(s,x);
-        }
+<head>
+    <script>
+      // Initialize intercom
+      // https://developers.intercom.com/installing-intercom/docs/basic-javascript
+      (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;
+      s.src='https://widget.intercom.io/widget/';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
+    </script>
+</head>
 
-        if(w.attachEvent){
-        w.attachEvent('onload',l);
-        }else{
-        w.addEventListener('load',l,false);
-        }
-        }
-        })();
-        </script>
-    </head>
-    <body>
-    </body>
-    </html>
+<body>
+</body>
+
+</html>

--- a/README.md
+++ b/README.md
@@ -11,24 +11,38 @@ Inside your project directory, install the package:
 
 You can use the component in your React Native component as follows:
 
-1. Import the IntercomWebView component:
+### Import the IntercomWebView component:
 
 ```javascript
 import IntercomWebView from 'react-native-intercom-webview';
 ```
 
-2. Render the IntercomWebView component:
+### Render the IntercomWebView component:
+
+#### Minimal configuration:
 
 ```javascript
 <IntercomWebView
-      appId="intercomappId"
-      name="intercom name"
-      email="intercom email"
-      defaultHeight={500}
-      hideLauncher={false}
-      showLoadingOverlay={true} />
+      appId="<Your intercom add id>"
+      name="<Your user's name>"
+      email="<Your user's email>"
+/>
 ```
-             
+
+#### Configuration:
+
+```javascript
+<IntercomWebView
+      appId="<Your intercom app_id>"
+      name="<Your user's name>"
+      email="<Your user's email>"
+      userHash={`...`}
+      showLoadingOverlay={false}
+      defaultHeight={500}
+      hideLauncher={true}
+/>
+```
+
 Change the intercom details (appId, name, email) to your own.
 
 The _hideLauncher_ prop hides the Intercom launcher icon and automatically shows the Intercom messages. This is useful for rendering the Intercom messages when a user clicks on your own custom launcher (e.g. a button).
@@ -37,7 +51,19 @@ If _defaultHeight_ is not provided, the IntercomWebView will attempt to fill the
 
 Any other WebView props (exluding: _source, injectedJavaScript, javaScriptEnabled_) can be passed to the IntercomWebView component as props and they will be passed onto the underlying WebView component.
 
-             
+### Hook into `onHide` event (closing of intercom chat):
+
+The example below assumes that you are using `react-navigation` and you want to navigate back.
+
+```javascript
+<IntercomWebView
+      ...
+      onMessage={(e) => e.nativeEvent.data === IntercomWebView.ON_HIDE_MESSAGE && this.props.navigation.goBack()}
+      ...
+/>
+```
+
+
 # Contribute
 To contribute, create a Pull Request:
 


### PR DESCRIPTION
* Improves `.html` file
* Adds `onClose` event via `window.postMessage`
* Adds description to README

I noticed that `onMessage` functinality was added and removed in the git history. I don't know why, probably there is a reason for that, but I can't find another way to track `onClose` event.